### PR TITLE
DOP-1956 Deploy of multiple versions of docs-kafka-connector from slack did not work properly

### DIFF
--- a/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
+++ b/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
@@ -72,19 +72,17 @@ exports = async function(payload, response) {
     if (!active) {
       continue;
     }
-    
-    // we use the primary alias for indexing search, not the original branch name (ie 'master'), for aliased repos 
-    if (publishOriginalBranchName && aliases) {
-      const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName,  hashOption, true, null)
-      context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail);  
-    }
-    
     //if this is stablebranch, we want autobuilder to know this is unaliased branch and therefore can reindex for search
     if (aliases === null) {
       const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName,  hashOption, false, null)
       context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail);  
     }
     else {
+          // we use the primary alias for indexing search, not the original branch name (ie 'master'), for aliased repos 
+      if (publishOriginalBranchName && aliases) {
+        const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName,  hashOption, true, null)
+        context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail);  
+      }
       aliases.forEach(function(alias, index) {
         const primaryAlias = (index === 0); 
         const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName, hashOption, true, alias, primaryAlias)

--- a/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
+++ b/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
@@ -80,16 +80,17 @@ exports = async function(payload, response) {
     }
     
     //if this is stablebranch, we want autobuilder to know this is unaliased branch and therefore can reindex for search
-    if (aliases === null) {
+    else if (aliases === null) {
       const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName,  hashOption, false, null)
       context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail);  
     }
-    
-    aliases.forEach(function(alias, index) {
-      const primaryAlias = (index === 0); 
-      const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName, hashOption, true, alias, primaryAlias)
-      context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail); 
-    })
+    else {
+      aliases.forEach(function(alias, index) {
+        const primaryAlias = (index === 0); 
+        const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName, hashOption, true, alias, primaryAlias)
+        context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail); 
+      })
+    }
   }
   
   //respond to modal

--- a/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
+++ b/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
@@ -80,7 +80,7 @@ exports = async function(payload, response) {
     }
     
     //if this is stablebranch, we want autobuilder to know this is unaliased branch and therefore can reindex for search
-    else if (aliases === null) {
+    if (aliases === null) {
       const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName,  hashOption, false, null)
       context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail);  
     }

--- a/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
+++ b/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
@@ -72,11 +72,12 @@ exports = async function(payload, response) {
     if (!active) {
       continue;
     }
-    //if this is stablebranch, we want autobuilder to know this is unaliased branch and therefore can reindex for search
+    //This is for non aliased branch
     if (aliases === null) {
       const newPayload = context.functions.execute("createNewPayload", "productionDeploy", repoOwner, repoName, branchName,  hashOption, false, null)
       context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail);  
     }
+    //if this is stablebranch, we want autobuilder to know this is unaliased branch and therefore can reindex for search
     else {
           // we use the primary alias for indexing search, not the original branch name (ie 'master'), for aliased repos 
       if (publishOriginalBranchName && aliases) {


### PR DESCRIPTION
Following are my observations while investigating this issue

- I see there are 3 conditional logic in the deployRepoStart webhook
    - With publishOriginalBranchName and aliases Present
    - Without aliases 
    - Without publishOriginalBranchName
- Whenever there is repo without aliases, i see a return right after we queue the job which results in only some branches are built. 

Testing:

- Used the test-deploy to build random repos, with branches and alias
- Verified i got notifications for all the branches i requested build for 
 Refer to this https://docs.google.com/spreadsheets/d/1zAgvw7VnlvwgBeOoc6cxID1cShrFBbaVgzN_vtbwhfw/edit?usp=sharing
