### PR TITLE
DOP-2064 Update the staging queue dashboard to pull from multiple staging collections

### DIFF
--- a/functions/getJobById/source.js
+++ b/functions/getJobById/source.js
@@ -1,9 +1,6 @@
-exports = function(jobId){
+exports = function(jobId, collName){
   const db_name = context.values.get("db_name");
-  const coll_name = context.values.get("coll_name");
-  
-  var queueCollection = context.services.get("mongodb-atlas").db(db_name).collection(coll_name);
-
+  var queueCollection = context.services.get("mongodb-atlas").db(db_name).collection(collName);
   return queueCollection.findOne({_id: BSON.ObjectId(jobId)}).then(doc => {
       return doc;
   });

--- a/functions/handleSlackSummaryMessages/source.js
+++ b/functions/handleSlackSummaryMessages/source.js
@@ -23,7 +23,6 @@ exports = async function(payload){
   
   // URL for the jobs dashboard site
   const jobUrl = `https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=${collName}&jobId=${jobId}`;
-  console.log(jobUrl)
   // Split email into mongoEmail and tenGenEmail or fail 
   let splits = email.split("@");
   if (splits[1] === "mongodb.com") {

--- a/functions/handleSlackSummaryMessages/source.js
+++ b/functions/handleSlackSummaryMessages/source.js
@@ -10,15 +10,20 @@ exports = async function(payload){
   // Get the Slack Service
   const slack = context.services.get("slackHTTPService");
   
-  // URL for the jobs dashboard site
-  const jobUrl = "https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?jobId=";
+  // get username/email mapping
+  var usernameMapping = context.functions.execute("getUsernameMapping");
   
   // Extract information from the payload
   const jobTitle = payload.fullDocument.title;
   const jobId = payload.fullDocument._id;
   const email = payload.fullDocument.email;
   const repoName = payload.fullDocument.payload.repoName;
+  const username = payload.fullDocument.user;
+  const collName = payload.ns.coll;
   
+  // URL for the jobs dashboard site
+  const jobUrl = `https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=${collName}&jobId=${jobId}`;
+  console.log(jobUrl)
   // Split email into mongoEmail and tenGenEmail or fail 
   let splits = email.split("@");
   if (splits[1] === "mongodb.com") {
@@ -28,13 +33,19 @@ exports = async function(payload){
     tenGenEmail = email;
     mongoEmail  = splits[0] + "@mongodb.com";
   } else {
-    console.log("Invalid email: " + email);
-    return;
+    console.log('private email found, now getting email from mapping object');
+    if (usernameMapping[username]) {
+      tenGenEmail = usernameMapping[username];
+      mongoEmail = tenGenEmail.replace('10gen.com', 'mongodb.com');
+    } else {
+      console.log("Invalid email: " + email);
+      return;
+    }
   }
   
   console.log("Update to: " + jobTitle + " (" + jobId + ")");
   console.log(JSON.stringify(payload.updateDescription));
-  
+
   // Compose the get request
   let getRequest = {
     scheme: scheme,
@@ -49,8 +60,6 @@ exports = async function(payload){
   // Issue the get request
   let getResp = await slack.get(getRequest);
   getResp = EJSON.parse(getResp.body.text());
-
-  console.log(payload.fullDocument);
   // If we did not get the email --> try the other one
   if (getResp.ok === false) {
     console.log("Couldnt find the mongodb email");
@@ -70,33 +79,43 @@ exports = async function(payload){
   }
   
   // split slack messages from build output and stage output
-  const slackMsgs = payload.fullDocument.comMessage;
+   const slackMsgs = payload.fullDocument.comMessage;
+
   
   // check if summary exists to send to slack 
   if (slackMsgs === undefined || slackMsgs.length === 0) {
+    console.log('ERROR: Empty slack message array.');
     return false;
   }
   
   // the last message is the one that has the staging output 
-  const lastMessage = slackMsgs[slackMsgs.length - 1];
+  let lastMessage = slackMsgs[slackMsgs.length - 1];
   
   // if last message is incorrect format 
-  if (lastMessage.indexOf('Summary') === -1) {
+  /*if (lastMessage.indexOf('Summary') === -1) {
+    console.log('ERROR: No Summary in output from build.');
     return false;
-  }
+  }*/
+  
+  // mms-docs builds two sites, so account for this in slack message
+  if (repoName === 'mms-docs') {
+    let modMmsOutput;
+    modMmsOutput = lastMessage.substr(0, lastMessage.indexOf('mut-publish'));
+    modMmsOutput = modMmsOutput + '\n\n';
+    modMmsOutput = modMmsOutput + lastMessage.substr(lastMessage.lastIndexOf('Summary'));
+    lastMessage = modMmsOutput;
+  } 
   
   // Compose the message including the job link
-  let message = "Your Job (<" + jobUrl + jobId + "|" +  jobTitle + ">) "; 
-  message += (slackMsgs.toString().indexOf('WARNING:') !== -1) ? 
-    "finished build with *WARNINGS*. " : 
-    "finished build with no warnings. ";
+  let message = "Your Job (<" + jobUrl + "|" +  jobTitle + ">) "; 
+  message += "finished! Please check the build log for any errors"
   // only get the summary portion of build output
-  message += '\n' + slackMsgs[slackMsgs.length - 1]; 
+  message += '\n' + lastMessage; 
   message += '\n' + "Enjoy!"; 
   message = message.replace(/\.{2,}/g, '');
   // testing
-  console.log('slack message length', slackMsgs.length);
-  console.log(message);
+
+  const bot_token = context.values.get("slack_bot_oauth_token")
   
   // Compose the post request
   let postRequest = {
@@ -104,7 +123,7 @@ exports = async function(payload){
     host: host,
     path: postMessage,
     query: {
-      token: [token], 
+      token: [bot_token], 
       channel: [getResp.user.id],
       text: [message],
      },
@@ -113,9 +132,6 @@ exports = async function(payload){
   // Issue the post request
   let postResp = await slack.post(postRequest);
   postResp = EJSON.parse(postResp.body.text());
-  
-  //what's the magic number?
-  console.log(222222, JSON.stringify(postResp));
   
   // Log and return the answer
   console.log(JSON.stringify(postResp));

--- a/functions/handleSlackTrigger/source.js
+++ b/functions/handleSlackTrigger/source.js
@@ -9,15 +9,21 @@ exports = async function(payload){
   // Get the Slack Service
   const slack = context.services.get("slackHTTPService");
   
-  // URL for the jobs dashboard site
-  const jobUrl = "https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?jobId=";
+  // get username/email mapping
+  var usernameMapping = context.functions.execute("getUsernameMapping");
   
+  
+  console.log(JSON.stringify(payload.fullDocument));
   // Extract information from the payload
   const jobTitle = payload.fullDocument.title;
   const jobId = payload.fullDocument._id;
   const email = payload.fullDocument.email;
   const repoName = payload.fullDocument.payload.repoName;
+  const username = payload.fullDocument.user;
+  const collName = payload.ns.coll;
   
+ // URL for the jobs dashboard site
+  const jobUrl = `https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=${collName}&jobId=${jobId}`;
   // Split email into mongoEmail and tenGenEmail or fail 
   let splits = email.split("@");
   if (splits[1] === "mongodb.com") {
@@ -27,8 +33,14 @@ exports = async function(payload){
     tenGenEmail = email;
     mongoEmail  = splits[0] + "@mongodb.com";
   } else {
-    console.log("Invalid email: " + email);
-    return;
+    console.log('private email found, now getting email from mapping object');
+    if (usernameMapping[username]) {
+      tenGenEmail = usernameMapping[username];
+      mongoEmail = tenGenEmail.replace('10gen.com', 'mongodb.com');
+    } else {
+      console.log("Invalid email: " + email);
+      return;
+    }
   }
   
   console.log("Update to: " + jobTitle + " (" + jobId + ")");
@@ -48,11 +60,13 @@ exports = async function(payload){
   // Issue the get request
   let getResp = await slack.get(getRequest);
   getResp = EJSON.parse(getResp.body.text());
+  console.log(JSON.stringify(getResp));
 
+  console.log(payload.fullDocument);
   // If we did not get the email --> try the other one
   if (getResp.ok === false) {
     console.log("Couldnt find the mongodb email");
-    console.log(JSON.stringify(getResp));
+    
     getRequest.query.email = [tenGenEmail];
     getResp = await slack.get(getRequest);
     getResp = EJSON.parse(getResp.body.text());
@@ -64,12 +78,12 @@ exports = async function(payload){
   }
   
   // Compose the message including the job link
-  let message = "Your Job (<" + jobUrl + jobId + "|" +  jobTitle + ">) ";  
+  let message = "Your Job (<" + jobUrl + "|" +  jobTitle + ">) ";  
   if (payload.operationType === "insert") {
     message += "has successfully been added to the queue.";
   } else {
     let newStatus = payload.fullDocument.status;
-    if (newStatus === "inProgress") {
+   if (newStatus === "inProgress") {
       message += "is now being processed.";
     } else if (newStatus === "completed") {
       message += "has successfully completed.";
@@ -80,6 +94,7 @@ exports = async function(payload){
     }
   }
   console.log(message);
+  const bot_token = context.values.get("slack_bot_oauth_token")
   
   // Compose the post request
   let postRequest = {
@@ -87,7 +102,7 @@ exports = async function(payload){
     host: host,
     path: postMessage,
     query: {
-      token: [token], 
+      token: [bot_token], 
       channel: [getResp.user.id],
       text: [message],
      },
@@ -96,8 +111,6 @@ exports = async function(payload){
   // Issue the post request
   let postResp = await slack.post(postRequest);
   postResp = EJSON.parse(postResp.body.text());
-  
-  console.log(222222, JSON.stringify(postResp));
   
   // Log and return the answer
   console.log(JSON.stringify(postResp));

--- a/functions/handleSlackTrigger/source.js
+++ b/functions/handleSlackTrigger/source.js
@@ -12,8 +12,6 @@ exports = async function(payload){
   // get username/email mapping
   var usernameMapping = context.functions.execute("getUsernameMapping");
   
-  
-  console.log(JSON.stringify(payload.fullDocument));
   // Extract information from the payload
   const jobTitle = payload.fullDocument.title;
   const jobId = payload.fullDocument._id;

--- a/hosting/files/js/index.js
+++ b/hosting/files/js/index.js
@@ -4,6 +4,14 @@ const stitchClient = stitch.Stitch.initializeDefaultAppClient(window.STITCH_APP_
 stitchClient.auth.loginWithCredential(new stitch.AnonymousCredential()).then(async user => {
 	console.log(`Logged in as anonymous user with id ${user.id}`);
 
+	const url = new URL(window.location.href);
+    const dict = {};
+    url.searchParams.forEach((v,k) => { dict[k] = v });
+
+	collName = 'queue';
+    if ('collName' in dict) {
+        collName = dict['collName'];
+    }
 	// Get Atlas client
 	const mongoClient = stitchClient.getServiceClient(
 		stitch.RemoteMongoClient.factory,
@@ -13,7 +21,7 @@ stitchClient.auth.loginWithCredential(new stitch.AnonymousCredential()).then(asy
 	const dbValues = await stitchClient.callFunction('getDBCollection');
 	
 	// Get a reference to the items database
-	const itemsCollection = mongoClient.db(dbValues.db_name).collection('queue');
+	const itemsCollection = mongoClient.db(dbValues.db_name).collection(collName);
 
 	/***************************************************************************** 
 	 *       Get the distributions of the status of jobs in the queue            *

--- a/hosting/files/js/job.js
+++ b/hosting/files/js/job.js
@@ -12,7 +12,13 @@ stitchClient.auth.loginWithCredential(new stitch.AnonymousCredential()).then(use
     url.searchParams.forEach((v,k) => { dict[k] = v });
     
     // Would like to switch this out eventually
-    stitchClient.callFunction("getJobById", [dict["jobId"]]).then(result => {
+    collName = 'queue';
+    if ('collName' in dict) {
+        collName = dict['collName'];
+    }
+    console.log(JSON.stringify(dict));
+
+    stitchClient.callFunction("getJobById", [dict["jobId"], collName]).then(result => {
         const job = {
             _id: result._id.toString(), 
             title: result.title, 

--- a/hosting/files/js/tables.js
+++ b/hosting/files/js/tables.js
@@ -24,6 +24,15 @@ if (type in typeToName) {
 stitchClient.auth.loginWithCredential(new stitch.AnonymousCredential()).then(async user => {
 	console.log(`Logged in as anonymous user with id ${user.id}`);
 
+    const url = new URL(window.location.href);
+    const dict = {};
+    url.searchParams.forEach((v,k) => { dict[k] = v });
+
+	collName = 'queue';
+    if ('collName' in dict) {
+        collName = dict['collName'];
+    }
+
 	// Get Atlas client
 	const mongoClient = stitchClient.getServiceClient(
 		stitch.RemoteMongoClient.factory,
@@ -33,7 +42,7 @@ stitchClient.auth.loginWithCredential(new stitch.AnonymousCredential()).then(asy
     const dbValues = await stitchClient.callFunction('getDBCollection');
 	
 	// Get a reference to the items database
-	const itemsCollection = mongoClient.db(dbValues.db_name).collection('queue');
+	const itemsCollection = mongoClient.db(dbValues.db_name).collection(collName);
 	
 	/***************************************************************************** 
 	 *       Get the distributions of the status of jobs in the queue            *

--- a/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
+++ b/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
@@ -55,7 +55,7 @@ exports = async function(payload, response) {
 
   let coll_name = context.values.get("coll_name");
   const collection_mappings = context.values.get("stage_collection_mapping");
-  if (parsed.user.id in collection_mappings) {
+  if (collection_mappings && parsed.user.id in collection_mappings) {
       coll_name = collection_mappings[parsed.user.id];
   }
   

--- a/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
+++ b/services/deployRepoOptions/incoming_webhooks/deployRepoStart/source.js
@@ -52,6 +52,12 @@ exports = async function(payload, response) {
       values[blockInputKey] = null;
     }
   }
+
+  let coll_name = context.values.get("coll_name");
+  const collection_mappings = context.values.get("stage_collection_mapping");
+  if (parsed.user.id in collection_mappings) {
+      coll_name = collection_mappings[parsed.user.id];
+  }
   
   for (let i = 0; i < values.repo_option.length; i++) {
     // // e.g. mongodb/docs-realm/master => (site/repo/branch)

--- a/services/mongoGithubPushedXlarge/incoming_webhooks/webhookxlarge/source.js
+++ b/services/mongoGithubPushedXlarge/incoming_webhooks/webhookxlarge/source.js
@@ -7,6 +7,15 @@
   
 exports = function(payload) {
   
+  var result = context.functions.execute("validateNewJob", payload);
+  
+  console.log(JSON.stringify(payload));
+
+  if (!result.valid) {
+    console.log(result.error);
+    return result.error ;
+  }
+  
   try {
     let jobTitle     = "Github Push: " + payload.repository.full_name;
     let jobUserName  = payload.pusher.name;
@@ -26,8 +35,13 @@ exports = function(payload) {
     }; 
     
     console.log(JSON.stringify(newPayload));
-    
-    context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail);  
+    let coll_name = context.values.get("coll_name");
+    const collection_mappings = context.values.get("stage_collection_mapping");
+    if (jobUserName in collection_mappings) {
+      coll_name = collection_mappings[jobUserName];
+    }
+    console.log(coll_name);
+    context.functions.execute("addJobToQueue", newPayload, jobTitle, jobUserName, jobUserEmail, coll_name);  
   } catch(err) {
     console.log(err);
   }

--- a/services/mongoGithubPushedXlarge/incoming_webhooks/webhookxlarge/source.js
+++ b/services/mongoGithubPushedXlarge/incoming_webhooks/webhookxlarge/source.js
@@ -37,7 +37,7 @@ exports = function(payload) {
     console.log(JSON.stringify(newPayload));
     let coll_name = context.values.get("coll_name");
     const collection_mappings = context.values.get("stage_collection_mapping");
-    if (jobUserName in collection_mappings) {
+    if (collection_mappings && jobUserName in collection_mappings) {
       coll_name = collection_mappings[jobUserName];
     }
     console.log(coll_name);


### PR DESCRIPTION
* Added the flexibility in getJobById to take in the collection to query the jobID
* Updated slack triggers to include the collection name in the dashboard URL
* Updated dashboard job file to use the collname passed in the querystring
* Updated GitHub Webhook to determine the collection based on the github user
* Updated slack deploy webhook to determine the collection based on the slack user

There are some manual steps to be done which will be automated in future:
* Create a collection
* Update the stage_collection_mapping (values) with the GitHub username and slack user id pointing to the newly created collection
* Update stage realm app Data access rules to include read access to the newly created collection 
* Create Triggers for insert and update to the new collection and linkit (refer to triggerSlackMessagesGuruColl and triggerSlackMessageInsertGuruColl)

Tests:
https://docs.google.com/spreadsheets/d/1_9RtCY1UzAZNDmGj0JH6EWvui_wa3cEv2VlMEpDY-JA/edit#gid=0
