### PR TITLE
DEVHUB-634: Webhooks for Devhub Production/Staging

### DIFF
--- a/services/strapi-build-webhook/config.json
+++ b/services/strapi-build-webhook/config.json
@@ -1,0 +1,6 @@
+{
+    "name": "strapi-build-webhook",
+    "type": "http",
+    "config": {},
+    "version": 1
+}

--- a/services/strapi-build-webhook/incoming_webhooks/strapi-production-webhook/config.json
+++ b/services/strapi-build-webhook/incoming_webhooks/strapi-production-webhook/config.json
@@ -1,0 +1,15 @@
+{
+    "name": "strapi-production-webhook",
+    "run_as_authed_user": false,
+    "run_as_user_id": "",
+    "run_as_user_id_script_source": "",
+    "can_evaluate": {},
+    "options": {
+        "httpMethod": "POST",
+        "validationMethod": "NO_VALIDATION"
+    },
+    "respond_result": true,
+    "disable_arg_logs": true,
+    "fetch_custom_user_data": false,
+    "create_user_on_auth": false
+}

--- a/services/strapi-build-webhook/incoming_webhooks/strapi-production-webhook/source.js
+++ b/services/strapi-build-webhook/incoming_webhooks/strapi-production-webhook/source.js
@@ -1,0 +1,37 @@
+// This function is the webhook's request handler.
+exports = async function (payload) {
+  // Data can be extracted from the request as follows:
+
+  // Raw request body (if the client sent one).
+  // This is a binary object that can be accessed as a string using .text()
+  const { email, name } = await JSON.parse(await payload.body.text());
+
+  try {
+    let jobTitle = "DevHub CMS Production Deploy";
+    let jobUserName = name;
+    let jobUserEmail = email;
+    const newPayload = {
+      jobType: "productionDeploy",
+      source: "strapi",
+      action: "push",
+      repoName: "devhub-content",
+      branchName: "master",
+      isFork: true,
+      private: true,
+      isXlarge: true,
+      repoOwner: "10gen",
+      url: "https://github.com/10gen/devhub-content",
+      newHead: null,
+    };
+
+    context.functions.execute(
+      "addJobToQueue",
+      newPayload,
+      jobTitle,
+      jobUserName,
+      jobUserEmail
+    );
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/services/strapi-build-webhook/incoming_webhooks/strapi-staging-webhook/config.json
+++ b/services/strapi-build-webhook/incoming_webhooks/strapi-staging-webhook/config.json
@@ -1,0 +1,15 @@
+{
+    "name": "strapi-staging-webhook",
+    "run_as_authed_user": false,
+    "run_as_user_id": "",
+    "run_as_user_id_script_source": "",
+    "can_evaluate": {},
+    "options": {
+        "httpMethod": "POST",
+        "validationMethod": "NO_VALIDATION"
+    },
+    "respond_result": true,
+    "disable_arg_logs": true,
+    "fetch_custom_user_data": false,
+    "create_user_on_auth": false
+}

--- a/services/strapi-build-webhook/incoming_webhooks/strapi-staging-webhook/source.js
+++ b/services/strapi-build-webhook/incoming_webhooks/strapi-staging-webhook/source.js
@@ -1,0 +1,34 @@
+// This function is the webhook's request handler.
+exports = async function (payload, response) {
+  const { email, name } = await JSON.parse(await payload.body.text());
+
+  try {
+    let jobTitle = "DevHub CMS Staging Build";
+    let jobUserName = name;
+    let jobUserEmail = email;
+    const newPayload = {
+      jobType: "githubPush",
+      source: "strapi",
+      action: "push",
+      repoName: "devhub-content-integration",
+      branchName: "test-strapi-webhook",
+      isFork: true,
+      private: true,
+      isXlarge: true,
+      // Can this be generalized to use the devhub-content master branch instead of my fork?
+      repoOwner: "jestapinski",
+      url: "https://github.com/jestapinski/devhub-content-integration.git",
+      newHead: "47796f9291f8237aaaaf2d9afcb5eec73566e156",
+    };
+
+    context.functions.execute(
+      "addJobToQueue",
+      newPayload,
+      jobTitle,
+      jobUserName,
+      jobUserEmail
+    );
+  } catch (err) {
+    console.log(err);
+  }
+};


### PR DESCRIPTION
Hi team!

This PR adds two webhooks into the Workerpool Realm App for DevHub to use with our new CMS on deploys to staging and production. We have one in there for Staging but I thought I would take this chance to clean that up while adding a similar one for production jobs.

We will handle calling these, I'm just hoping that these make sense and maybe there aren't any potential updates we could make? Any thoughts would be great! I'm also just going a bit blind here.

Thanks a ton!